### PR TITLE
Fix bug from issue 5562 (#5565)

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -44,6 +44,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QStyleOption>
+#include <QVariant>
 
 
 #include "AutomationPattern.h"
@@ -2250,6 +2251,8 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 	element.setAttribute( "name", name() );
 	m_mutedModel.saveSettings( doc, element, "muted" );
 	m_soloModel.saveSettings( doc, element, "solo" );
+	// Save the mutedBeforeSolo value so we can recover the muted state if any solo was active (issue 5562)
+	element.setAttribute( "mutedBeforeSolo", int(m_mutedBeforeSolo) );
 
 	if( m_height >= MINIMAL_TRACK_HEIGHT )
 	{
@@ -2304,6 +2307,9 @@ void Track::loadSettings( const QDomElement & element )
 
 	m_mutedModel.loadSettings( element, "muted" );
 	m_soloModel.loadSettings( element, "solo" );
+	// Get the mutedBeforeSolo value so we can recover the muted state if any solo was active.
+	// Older project files that didn't have this attribute will set the value to false (issue 5562)
+	m_mutedBeforeSolo = QVariant( element.attribute( "mutedBeforeSolo", "0" ) ).toBool();
 
 	if( m_simpleSerializingMode )
 	{


### PR DESCRIPTION
Fixes a small bug where projects that are saved with a soloed track can't restore the muted state of other tracks, because it doesn't store the m_mutedBeforeSolo variable on the project file.

With this fix, a new attribute is added to the Track DOM element, containing the muted state of tracks before the solo. When loading older projects that don't contain this attribute m_mutedBeforeSolo will be set to false.